### PR TITLE
linux specific support for disk poweroff

### DIFF
--- a/src/main/java/org/luwrain/linux/DefaultDisksPopupFactory.java
+++ b/src/main/java/org/luwrain/linux/DefaultDisksPopupFactory.java
@@ -98,6 +98,21 @@ public final class DefaultDisksPopupFactory implements DisksPopup.Factory
 		throw new RuntimeException(e);
 	    }
 	}
+
+@Override public boolean poweroff(Set<DisksPopup.Flags> flags)
+	{
+	    final UdisksCli u = new UdisksCli();
+	    try {
+		u.poweroff(device);
+		return true;
+	    }
+	    catch(Throwable e)
+	    {
+		throw new RuntimeException(e);
+	    }
+	}
+	
+
 	@Override public String toString()
 	{
 	    return title;

--- a/src/main/java/org/luwrain/linux/DefaultDisksPopupFactory.java
+++ b/src/main/java/org/luwrain/linux/DefaultDisksPopupFactory.java
@@ -1,5 +1,6 @@
 /*
    Copyright 2012-2022 Michael Pozhidaev <michael.pozhidaev@gmail.com>
+Copyright 2022 ilya paschuk <ilusha.paschuk@gmail.com>
 
    This file is part of LUWRAIN.
 

--- a/src/main/java/org/luwrain/linux/services/UdisksCli.java
+++ b/src/main/java/org/luwrain/linux/services/UdisksCli.java
@@ -1,5 +1,6 @@
 /*
    Copyright 2012-2022 Michael Pozhidaev <msp@luwrain.org>
+Copyright 2022 ilya paschuk <ilusha.paschuk@gmail.com>
 
    This file is part of LUWRAIN.
 

--- a/src/main/java/org/luwrain/linux/services/UdisksCli.java
+++ b/src/main/java/org/luwrain/linux/services/UdisksCli.java
@@ -75,6 +75,12 @@ public final class UdisksCli
 	caller.call(new String[]{"unmount", "-b", device});
     }
 
+public void poweroff(String device) throws IOException
+    {
+	caller.call(new String[]{"power-off", "-b", device});
+    }
+
+
     static public Caller createDefaultCaller()
     {
 	return (args)->{


### PR DESCRIPTION
this pr adds disk poweroff support to the linux udisks based disks popup.

'udisksctl power-off' command is used for this.

this feature can be useful to correctly disconnect external hard drives, for which simple unmount is not enough.